### PR TITLE
fix(groups): use default group profile layout if custom unavailable

### DIFF
--- a/views/default/resources/groups/profile.php
+++ b/views/default/resources/groups/profile.php
@@ -24,8 +24,10 @@ $vars['entity'] = $entity;
 $subtype = $entity->getSubtype() ? : 'default';
 if (elgg_view_exists("profiles/group/$subtype")) {
 	$content = elgg_view("profiles/group/$subtype", $vars);
-} else {
+} elseif (elgg_view_exists("profiles/group/default")) {
 	$content = elgg_view('profiles/group/default', $vars);
+} else {
+	$content = elgg_view('groups/profile/layout', $vars);
 }
 
 $filter = elgg_view('filters/groups/profile', $vars);


### PR DESCRIPTION
Handle the missing "profiles/group/default" view.

I assume you've got this on a site where you've defined profiles/group/default in a theme plugin.